### PR TITLE
Match selector ids as #lowercase, not [id=]

### DIFF
--- a/lib/abp2blocklist.js
+++ b/lib/abp2blocklist.js
@@ -595,7 +595,7 @@ function convertFilterAddRules(rules, filter, action, withResourceTypes,
   }
 }
 
-function convertIDSelectorsToAttributeSelectors(selector)
+function convertIDSelectorsToLowerCase(selector)
 {
   // First we figure out where all the IDs are
   let sep = "";
@@ -638,7 +638,7 @@ function convertIDSelectorsToAttributeSelectors(selector)
   for (let pos of positions)
   {
     newSelector.push(selector.substring(i, pos.start));
-    newSelector.push('[id=', selector.substring(pos.start + 1, pos.end), ']');
+    newSelector.push(selector.substring(pos.start, pos.end).toLowerCase());
     i = pos.end;
   }
   newSelector.push(selector.substring(i));
@@ -663,8 +663,8 @@ function addCSSRules(rules, selectors, domain, exceptionDomains)
     let selector = selectors.splice(0, selectorLimit).join(", ");
 
     // As of Safari 9.0 element IDs are matched as lowercase. We work around
-    // this by converting to the attribute format [id="elementID"]
-    selector = convertIDSelectorsToAttributeSelectors(selector);
+    // this by converting to lowercase (attribute matching is too slow)
+    selector = convertIDSelectorsToLowerCase(selector);
 
     let rule = {
       trigger: {"url-filter": matchDomain(domain),

--- a/test/abp2blocklist.js
+++ b/test/abp2blocklist.js
@@ -188,7 +188,7 @@ exports.generateRules = {
     runTest(test, [
       testRules(test,
                 ["###example", "test.com###EXAMPLE"],
-                ["[id=example]", "[id=EXAMPLE]"],
+                ["#example", "#example"],
                 rules => rules.map(rule => rule.action.selector))
     ]);
   },
@@ -347,7 +347,7 @@ exports.generateRules = {
       testRules(test, ["🐈%F0%9F%90%88$domain=🐈.cat"],
                 "^[^:]+:(//)?.*%F0%9F%90%88%F0%9F%90%88",
                 rules => rules[0]["trigger"]["url-filter"]),
-      testRules(test, ["###🐈"], "[id=🐈]",
+      testRules(test, ["###🐈"], "#🐈",
                 rules => rules[0]["action"]["selector"])
     ]);
   },


### PR DESCRIPTION
Attribute matching carried a sizable performance penalty, slowing page
rendering. Instead, match IDs using lowercase selectors. This may
erroneously match elements whose IDs vary from the target only by case.
Despite this risk, the #lowercase approach is chosen for its balance
between fidelity and performance.